### PR TITLE
Check for queued items on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When using Strapi as a headless CMS for a statically built website you need a wa
 
 This plugin tackles the publishing flow a different way. The site administrators can take their time and make many changes and once the content update is complete they can trigger a single build.
 
-This plugin also checks to see if an `in_progress` build is active and not allow the user to trigger another. Also, when a build has been triggered the user can wait on the plugin page to see when the build and deployment has completed.
+This plugin also checks to see if an `in_progress` build is active or if anything is in the `queue` and not allow the user to trigger another. Also, when a build has been triggered the user can wait on the plugin page to see when the build and deployment has completed.
 
 ## Installation
 

--- a/admin/src/containers/HomePage/index.js
+++ b/admin/src/containers/HomePage/index.js
@@ -9,10 +9,10 @@ import { useGlobalContext, request } from "strapi-helper-plugin";
 
 import pluginId from "../../pluginId";
 
+const POLL_INTERVAL = 10000;
+
 const HomePage = () => {
   const { formatMessage } = useGlobalContext();
-  const checkTimeout = useRef();
-  const [checkNumber, setCheckNumber] = useState(0);
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -23,31 +23,20 @@ const HomePage = () => {
       setBusy(busy);
       setReady(true);
 
-      checkTimeout.current = setTimeout(() => {
-        setCheckNumber(checkNumber + 1);
-      }, 5000);
+      const timeout = setTimeout(checkBusy, POLL_INTERVAL);
     };
 
     checkBusy();
 
     return () => {
-      clearTimeout(checkTimeout.current);
+      clearTimeout(timeout);
     };
-  }, [checkNumber, setCheckNumber]);
+  }, []);
 
   const triggerPublish = async () => {
     setBusy(true);
-    clearTimeout(checkTimeout.current);
 
-    const { success } = await request(`/${pluginId}/publish`, {
-      method: "GET",
-    });
-
-    if (success) {
-      setTimeout(() => {
-        setCheckNumber(checkNumber + 1);
-      }, 20000);
-    }
+    await request(`/${pluginId}/publish`, { method: "GET" });
   };
 
   const handleClick = () => {

--- a/controllers/github-publish.js
+++ b/controllers/github-publish.js
@@ -17,13 +17,16 @@ module.exports = {
     };
 
     const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs?branch=${branch}`;
-    const { data: data1 } = await axios.get(`${url}&status=in_progress`, {
+    const { data: inProgressData } = await axios.get(
+      `${url}&status=in_progress`,
+      {
+        headers,
+      }
+    );
+    const { data: queuedData } = await axios.get(`${url}&status=queued`, {
       headers,
     });
-    const { data: data2 } = await axios.get(`${url}&status=queued`, {
-      headers,
-    });
-    const busy = !!(data1.total_count + data2.total_count);
+    const busy = !!(inProgressData.total_count + queuedData.total_count);
 
     ctx.send({ busy });
   },

--- a/controllers/github-publish.js
+++ b/controllers/github-publish.js
@@ -16,9 +16,14 @@ module.exports = {
       Authorization: "token " + token,
     };
 
-    const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs?branch=${branch}&status=in_progress`;
-    const { data } = await axios.get(url, { headers });
-    const busy = !!data.total_count;
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs?branch=${branch}`;
+    const { data: data1 } = await axios.get(`${url}&status=in_progress`, {
+      headers,
+    });
+    const { data: data2 } = await axios.get(`${url}&status=queued`, {
+      headers,
+    });
+    const busy = !!(data1.total_count + data2.total_count);
 
     ctx.send({ busy });
   },


### PR DESCRIPTION
Makes the check function query `queued` as well as `in_progress` workflows increasing stability and we can also remove the 20s check after publishing.