### PR TITLE
Add support for GitHub workflow inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ module.exports = ({ env }) => ({
     workflow_id: "rebuild.yml", // The workflow_id or filename
     token: env("GITHUB_TOKEN"), // The GitHub personal access token with access to trigger workflows and view build status
     branch: "master", // The branch the workflow should be triggered on
+    inputs: {
+      // Inputs to pass through to the GitHub workflow
+      some_input: "Some value",
+      some_other_input: "Some other value",
+    },
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module.exports = ({ env }) => ({
     token: env("GITHUB_TOKEN"), // The GitHub personal access token with access to trigger workflows and view build status
     branch: "master", // The branch the workflow should be triggered on
     inputs: {
-      // Inputs to pass through to the GitHub workflow
+      // Optional inputs to pass through to the GitHub workflow
       some_input: "Some value",
       some_other_input: "Some other value",
     },

--- a/controllers/github-publish.js
+++ b/controllers/github-publish.js
@@ -32,16 +32,21 @@ module.exports = {
   },
 
   publish: async (ctx) => {
-    const { owner, repo, workflow_id, token, branch: ref } = strapi.plugins[
-      pluginId
-    ].config;
+    const {
+      owner,
+      repo,
+      workflow_id,
+      token,
+      branch: ref,
+      inputs = {},
+    } = strapi.plugins[pluginId].config;
 
     const headers = {
       Accept: "application/vnd.github.v3+json",
       Authorization: "token " + token,
     };
 
-    const data = { ref };
+    const data = { ref, inputs };
 
     const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`;
     const { status } = await axios.post(url, data, { headers });


### PR DESCRIPTION
In some cases for workflows triggered via `workflow_dispatch` it is useful to specify inputs that are passed to the workflow, [see here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onworkflow_dispatchinputs).

This PR adds support for optional workflow inputs as key-value pairs which are passed on to GitHub when triggering a dispatch event.