### PR TITLE
missing package.json info

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.2.0",
   "description": "A plugin to easily trigger GitHub Actions workflows from Strapi.",
   "strapi": {
-    "name": "GitHub Publishing",
+    "name": "github-publish",
     "icon": "plug",
+    "kind": "plugin",
     "description": "Publish changes via GitHub Actions."
   },
   "dependencies": {},


### PR DESCRIPTION
hi @digitaljohn 
looks like Strapi v4 PR was missing a package.json change, sorry for the inconvenience