### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish-npm:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/phantomstudios/strapi-plugin-github-publish/security/code-scanning/2](https://github.com/phantomstudios/strapi-plugin-github-publish/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves publishing to npm, it requires `contents: read` to access the repository contents and `packages: write` to publish the package. These permissions will be explicitly defined at the job level to limit their scope to the `publish-npm` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
